### PR TITLE
⚡ Cache is_on_floor() in player script

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -13,7 +13,7 @@ var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 var facing_right = true
 
 func _physics_process(delta):
-	var on_floor = is_on_floor()
+	var on_floor := is_on_floor()
 
 	# Add the gravity.
 	if not on_floor:
@@ -46,7 +46,7 @@ func _physics_process(delta):
 	on_floor = is_on_floor()
 	update_animation(on_floor)
 
-func update_animation(on_floor: bool):
+func update_animation(on_floor: bool = is_on_floor()):
 	# Null check to handle potential missing AnimationPlayer node
 	if not animation_player:
 		return

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -46,7 +46,7 @@ func _physics_process(delta):
 	on_floor = is_on_floor()
 	update_animation(on_floor)
 
-func update_animation(on_floor: bool = is_on_floor()):
+func update_animation(on_floor: bool):
 	# Null check to handle potential missing AnimationPlayer node
 	if not animation_player:
 		return

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -13,12 +13,14 @@ var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 var facing_right = true
 
 func _physics_process(delta):
+	var on_floor = is_on_floor()
+
 	# Add the gravity.
-	if not is_on_floor():
+	if not on_floor:
 		velocity.y += gravity * delta
 
 	# Handle jump.
-	if Input.is_action_just_pressed("jump") and is_on_floor():
+	if Input.is_action_just_pressed("jump") and on_floor:
 		velocity.y = JUMP_VELOCITY
 
 	# Get the input direction and handle the movement/deceleration.
@@ -41,14 +43,15 @@ func _physics_process(delta):
 	move_and_slide()
 	
 	# Update animations
-	update_animation()
+	on_floor = is_on_floor()
+	update_animation(on_floor)
 
-func update_animation():
+func update_animation(on_floor: bool):
 	# Null check to handle potential missing AnimationPlayer node
 	if not animation_player:
 		return
 	
-	if not is_on_floor():
+	if not on_floor:
 		animation_player.play("jump")
 	elif abs(velocity.x) > 0:
 		animation_player.play("run")


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Caching the result of `is_on_floor()` in a local variable `on_floor` within `_physics_process`.
- Reusing this variable for gravity and jump checks.
- Refreshing the variable after `move_and_slide()` and passing it to `update_animation(on_floor)`.

🎯 **Why:** The performance problem it solves
- Each call to `is_on_floor()` involves a cross-language (GDScript to C++) call.
- Reducing these calls in the `_physics_process` loop (which runs 60+ times per second) is a standard optimization.
- It also makes the code cleaner by explicitly showing which state is being used for logic.

📊 **Measured Improvement:**
- Measurement was not possible in this environment as the Godot engine and benchmarking tools were not available.
- Rationale: Reducing from 3 calls to 2 calls per frame is a 33% reduction in `is_on_floor()` calls per physics frame. While the impact of a single call is small, this is a best practice for high-frequency physics logic.

---
*PR created automatically by Jules for task [1720609983106231814](https://jules.google.com/task/1720609983106231814) started by @splk3*